### PR TITLE
feat: add save and get analysis result API for share result

### DIFF
--- a/src/controllers/analysisController.js
+++ b/src/controllers/analysisController.js
@@ -28,8 +28,40 @@ export const saveAnalysisResult = async (req, res) => {
       return res.status(401).json({ message: '인증되지 않은 사용자입니다.' });
     }
 
-    if (!pageContent || !accessibilityAnalysis || !screenReaderScript || !selectedScreenReader) {
-      return res.status(400).json({ message: '저장할 분석 결과 데이터가 부족합니다.' });
+    if (!pageContent || typeof pageContent !== 'string' || pageContent.trim().length === 0) {
+      return res.status(400).json({
+        message: 'pageContent 필드는 비어 있지 않은 문자열이어야 합니다.',
+      });
+    }
+
+    if (
+      !accessibilityAnalysis ||
+      typeof accessibilityAnalysis !== 'object' ||
+      Object.keys(accessibilityAnalysis).length === 0
+    ) {
+      return res.status(400).json({
+        message: 'accessibilityAnalysis 필드는 비어 있지 않은 객체여야 합니다.',
+      });
+    }
+
+    if (
+      !screenReaderScript ||
+      !Array.isArray(screenReaderScript) ||
+      screenReaderScript.length === 0
+    ) {
+      return res.status(400).json({
+        message: 'screenReaderScript 필드는 비어 있지 않은 배열이어야 합니다.',
+      });
+    }
+
+    if (
+      !selectedScreenReader ||
+      typeof selectedScreenReader !== 'string' ||
+      selectedScreenReader.trim().length === 0
+    ) {
+      return res.status(400).json({
+        message: 'selectedScreenReader 필드는 비어 있지 않은 문자열이어야 합니다.',
+      });
     }
 
     const analysisId = await saveAnalysis({

--- a/src/controllers/analysisController.js
+++ b/src/controllers/analysisController.js
@@ -1,6 +1,7 @@
 import { analyzeAccessibility } from '../services/analysis/index.js';
+import { saveAnalysis, getAnalysisById } from '../services/analysisService.js';
 
-export const handleAnalysisRequest = async (req, res) => {
+export const performAnalysis = async (req, res) => {
   try {
     const { url, htmlContent, screenReader } = req.body;
 
@@ -13,6 +14,51 @@ export const handleAnalysisRequest = async (req, res) => {
     res.status(200).json(results);
   } catch (error) {
     console.error('분석 요청 처리 중 에러 발생:', error);
+    res.status(500).json({ message: error.message || '서버 내부 오류가 발생했습니다.' });
+  }
+};
+
+export const saveAnalysisResult = async (req, res) => {
+  try {
+    const { pageContent, accessibilityAnalysis, screenReaderScript, selectedScreenReader } =
+      req.body;
+    const userId = req.userId;
+
+    if (!userId) {
+      return res.status(401).json({ message: '인증되지 않은 사용자입니다.' });
+    }
+
+    if (!pageContent || !accessibilityAnalysis || !screenReaderScript || !selectedScreenReader) {
+      return res.status(400).json({ message: '저장할 분석 결과 데이터가 부족합니다.' });
+    }
+
+    const analysisId = await saveAnalysis({
+      userId,
+      pageContent,
+      accessibilityAnalysis,
+      screenReaderScript,
+      selectedScreenReader,
+    });
+
+    res.status(201).json({ id: analysisId, message: '분석 결과가 성공적으로 저장되었습니다.' });
+  } catch (error) {
+    console.error('분석 결과 저장 중 에러 발생:', error);
+    res.status(500).json({ message: error.message || '서버 내부 오류가 발생했습니다.' });
+  }
+};
+
+export const getAnalysisResult = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const analysis = await getAnalysisById(id);
+
+    if (!analysis) {
+      return res.status(404).json({ message: '분석 결과를 찾을 수 없습니다.' });
+    }
+
+    res.status(200).json(analysis);
+  } catch (error) {
+    console.error('분석 결과 조회 중 에러 발생:', error);
     res.status(500).json({ message: error.message || '서버 내부 오류가 발생했습니다.' });
   }
 };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -30,7 +30,7 @@ export const handleKakaoLogin = async (req, res) => {
     res.cookie('accessToken', token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 1000 * 24,
     });

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import 'dotenv/config';
 import cors from 'cors';
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import jwt from 'jsonwebtoken';
+import { authenticateToken } from './middleware/authMiddleware.js';
 import authRouter from './routes/auth.js';
 import analysisRouter from './routes/analysis.js';
 
@@ -15,27 +15,14 @@ app.use(
     credentials: true,
   })
 );
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 app.use(cookieParser());
 
 app.use('/api/auth', authRouter);
 app.use('/api/analysis', analysisRouter);
 
-app.get('/api/users/me', (req, res) => {
-  try {
-    const token = req.cookies.accessToken;
-    if (!token) {
-      return res.status(401).json({ message: '인증되지 않았습니다.' });
-    }
-
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-
-    res.status(200).json({ userId: decoded.userId });
-  } catch (error) {
-    console.error(error);
-
-    res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
-  }
+app.get('/api/users/me', authenticateToken, (req, res) => {
+  res.status(200).json({ userId: req.userId });
 });
 
 const PORT = process.env.PORT || 8080;

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ app.use(
     credentials: true,
   })
 );
-app.use(express.json({ limit: '50mb' }));
+app.use(express.json({ limit: '10mb' }));
 app.use(cookieParser());
 
 app.use('/api/auth', authRouter);

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+
+export const authenticateToken = (req, res, next) => {
+  const token = req.cookies.accessToken;
+
+  if (!token) {
+    return res.status(401).json({ message: '인증되지 않았습니다. 로그인이 필요합니다.' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.userId = decoded.userId;
+
+    next();
+  } catch (error) {
+    console.error('토큰 검증 실패:', error);
+
+    return res.status(403).json({ message: '유효하지 않거나 만료된 토큰입니다.' });
+  }
+};

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -7,13 +7,19 @@ export const authenticateToken = (req, res, next) => {
     return res.status(401).json({ message: '인증되지 않았습니다. 로그인이 필요합니다.' });
   }
 
+  if (!process.env.JWT_SECRET) {
+    console.error('JWT_SECRET이 설정되어 있지 않습니다.');
+
+    return res.status(500).json({ message: '서버 설정 오류가 발생했습니다.' });
+  }
+
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.userId = decoded.userId;
 
     next();
-  } catch (error) {
-    console.error('토큰 검증 실패:', error);
+  } catch {
+    console.error('토큰 검증 실패: 유효하지 않은 토큰');
 
     return res.status(403).json({ message: '유효하지 않거나 만료된 토큰입니다.' });
   }

--- a/src/routes/analysis.js
+++ b/src/routes/analysis.js
@@ -1,9 +1,16 @@
 import express from 'express';
 
-import { handleAnalysisRequest } from '../controllers/analysisController.js';
+import {
+  performAnalysis,
+  saveAnalysisResult,
+  getAnalysisResult,
+} from '../controllers/analysisController.js';
+import { authenticateToken } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
-router.post('/', handleAnalysisRequest);
+router.post('/perform', performAnalysis);
+router.post('/', authenticateToken, saveAnalysisResult);
+router.get('/:id', getAnalysisResult);
 
 export default router;

--- a/src/services/analysisService.js
+++ b/src/services/analysisService.js
@@ -1,0 +1,50 @@
+import { supabase } from './supabaseClient.js';
+
+export const saveAnalysis = async ({
+  userId,
+  pageContent,
+  accessibilityAnalysis,
+  screenReaderScript,
+  selectedScreenReader,
+}) => {
+  const { data, error } = await supabase
+    .from('analyses')
+    .insert([
+      {
+        user_id: userId,
+        page_content: pageContent,
+        accessibility_analysis: accessibilityAnalysis,
+        screen_reader_script: screenReaderScript,
+        selected_screen_reader: selectedScreenReader,
+      },
+    ])
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('Error saving analysis:', error);
+    throw new Error(`분석 결과 저장 실패: ${error.message}`);
+  }
+
+  return data.id;
+};
+
+export const getAnalysisById = async (id) => {
+  const { data, error } = await supabase
+    .from('analyses')
+    .select('page_content, accessibility_analysis, screen_reader_script, selected_screen_reader')
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    console.error('Error fetching analysis by ID:', error);
+    throw new Error(`분석 결과 조회 실패: ${error.message}`);
+  }
+
+  return {
+    pageContent: data.page_content,
+    accessibilityAnalysis: data.accessibility_analysis,
+    screenReaderScript: data.screen_reader_script,
+    selectedScreenReader: data.selected_screen_reader,
+  };
+};

--- a/src/services/analysisService.js
+++ b/src/services/analysisService.js
@@ -7,6 +7,26 @@ export const saveAnalysis = async ({
   screenReaderScript,
   selectedScreenReader,
 }) => {
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('유효하지 않은 사용자 ID입니다.');
+  }
+
+  if (!pageContent || typeof pageContent !== 'string') {
+    throw new Error('pageContent는 문자열이어야 합니다.');
+  }
+
+  if (typeof accessibilityAnalysis !== 'object' || accessibilityAnalysis === null) {
+    throw new Error('accessibilityAnalysis는 객체여야 합니다.');
+  }
+
+  if (!Array.isArray(screenReaderScript)) {
+    throw new Error('screenReaderScript는 배열이어야 합니다.');
+  }
+
+  if (!selectedScreenReader || typeof selectedScreenReader !== 'string') {
+    throw new Error('selectedScreenReader는 문자열이어야 합니다.');
+  }
+
   const { data, error } = await supabase
     .from('analyses')
     .insert([
@@ -23,7 +43,7 @@ export const saveAnalysis = async ({
 
   if (error) {
     console.error('Error saving analysis:', error);
-    throw new Error(`분석 결과 저장 실패: ${error.message}`);
+    throw new Error('데이터베이스 오류로 분석 결과 저장에 실패했습니다.');
   }
 
   return data.id;


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #9 

### 📌 설명

다음 작업을 진행한 Pull Request 입니다.

- 로그인한 사용자만 접근 가능한 분석 결과 저장 API와 링크를 공유하면 결과 id 값을 토대로 조회할 수 있는 API를 추가했습니다.
- Supabase를 통해 분석 결과를 DB에 저장하고, ID 기반으로 조회할 수 있도록 구성했습니다.
- 기존의 분석 요청 로직은 그대로 유지하며, 저장은 별도로 분리했습니다.

### 📃 작업 사항

- [x] 인증 미들웨어(authenticateToken) 생성 및 적용
- [x] /api/analysis POST 라우트에 저장 기능 추가
- [x] /api/analysis/:id GET 라우트에 조회 기능 추가
- [x] analysisService.js에 저장/조회 로직 구현
- [x] analysisController.js에 saveAnalysisResult, getAnalysisResult 함수 추가
- [x] 기존 분석 요청 핸들러 이름을 performAnalysis로 변경
- [x] 쿠키 기반 인증 사용자 식별로 userId 연결

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to save accessibility analysis results, requiring user authentication.
  * Introduced an endpoint to retrieve saved analysis results by ID.
  * Implemented persistent storage for analysis data.

* **Improvements**
  * JWT authentication is now handled by a dedicated middleware for improved security and maintainability.
  * Cookie settings for login have been updated to improve cross-site request compatibility.
  * Increased the maximum size limit for incoming JSON requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->